### PR TITLE
Update trackitem.rst

### DIFF
--- a/docs/item/trackitem.rst
+++ b/docs/item/trackitem.rst
@@ -408,7 +408,7 @@ Moves the inPoint of the track item to a new time.
 ===================  ============  =======================
 Argument             Type          Description
 ===================  ============  =======================
-``newInPoint``       ``Time``      The time to which to move the track item's in point.
+``newInPoint``       ``Time``      The time in seconds to shift the track item's start.
 ===================  ============  =======================
 
 **Returns**


### PR DESCRIPTION
TrackItem.move() method needs description correction;
It seems like it will shift track start for number of seconds of newInPoint Argument, instead of move to this time.
Clip.start instead of in point.
tested on Premier 2021 win.