### PR TITLE
Fixes return text for `areKeyframesSupported`

### DIFF
--- a/docs/sequence/componentparam.rst
+++ b/docs/sequence/componentparam.rst
@@ -81,7 +81,7 @@ None.
 
 **Returns**
 
-Returns ``true`` if trackItem is selected; ``false`` if not.
+Returns ``true`` if keyframes are supported; ``false`` if not.
 
 ----
 


### PR DESCRIPTION
For `ComponentParam.areKeyframesSupported()`

**Returns**
```diff
- Returns `true` if trackItem is selected; `false` if not.
+ Returns `true` if keyframes are supported; `false` if not.
```