### PR TITLE
Update TrackItem Definitions

### DIFF
--- a/docs/item/trackitem.rst
+++ b/docs/item/trackitem.rst
@@ -56,7 +56,7 @@ TrackItem.end
 
 **Description**
 
-The ending time of the trackItem. Note: This may differ, from the trackItem's out point.
+The absolute end time of the trackItem in the timeline. This does not consider the visible clip trimming (determined by ``TrackItem.inPoint`` and ``TrackItem.outPoint``). Note: This may differ, from the trackItem's out point.
 
 **Type**
 
@@ -72,7 +72,7 @@ TrackItem.inPoint
 
 **Description**
 
-The in point for media, in this trackItem.
+The in point set on the source clip for this trackItem. This is also the time trimmed from the clip's start (``TrackItem.start``), as seen in the timeline.
 
 **Type**
 
@@ -152,7 +152,7 @@ TrackItem.outPoint
 
 **Description**
 
-The out point for media, in this trackItem.
+The out point set on the source clip for this trackItem. This is also the time trimmed from the clip's end (``TrackItem.end``), as seen in the timeline.
 
 **Type**
 
@@ -184,7 +184,7 @@ TrackItem.start
 
 **Description**
 
-The starting time of the trackItem. Note: This may differ, from the trackItem's in point.
+The absolute start time of the trackItem, in the timeline. This does not consider the visible clip trimming (determined by ``TrackItem.inPoint`` and ``TrackItem.outPoint``). Note: This may differ, from the trackItem's in point.
 
 **Type**
 

--- a/docs/item/trackitem.rst
+++ b/docs/item/trackitem.rst
@@ -56,7 +56,7 @@ TrackItem.end
 
 **Description**
 
-The absolute end time of the trackItem in the timeline. This does not consider the visible clip trimming (determined by ``TrackItem.inPoint`` and ``TrackItem.outPoint``). Note: This may differ, from the trackItem's out point.
+The ending time of the trackItem. Note: This may differ, from the trackItem's out point.
 
 **Type**
 
@@ -72,7 +72,7 @@ TrackItem.inPoint
 
 **Description**
 
-The in point set on the source clip for this trackItem. This is also the time trimmed from the clip's start (``TrackItem.start``), as seen in the timeline.
+The in point for media, in this trackItem.
 
 **Type**
 
@@ -152,7 +152,7 @@ TrackItem.outPoint
 
 **Description**
 
-The out point set on the source clip for this trackItem. This affects the time trimmed from the clip's end (``TrackItem.end``), as seen in the timeline.
+The out point for media, in this trackItem.
 
 **Type**
 
@@ -184,7 +184,7 @@ TrackItem.start
 
 **Description**
 
-The absolute start time of the trackItem in the timeline. This does not consider the visible clip trimming (determined by ``TrackItem.inPoint`` and ``TrackItem.outPoint``). Note: This may differ, from the trackItem's in point.
+The starting time of the trackItem. Note: This may differ, from the trackItem's in point.
 
 **Type**
 

--- a/docs/item/trackitem.rst
+++ b/docs/item/trackitem.rst
@@ -152,7 +152,7 @@ TrackItem.outPoint
 
 **Description**
 
-The out point set on the source clip for this trackItem. This is also the time trimmed from the clip's end (``TrackItem.end``), as seen in the timeline.
+The out point set on the source clip for this trackItem. This affects the time trimmed from the clip's end (``TrackItem.end``), as seen in the timeline.
 
 **Type**
 

--- a/docs/item/trackitem.rst
+++ b/docs/item/trackitem.rst
@@ -56,7 +56,7 @@ TrackItem.end
 
 **Description**
 
-The ending time of the trackItem. Note: This may differ, from the trackItem's out point.
+The visible end time of the trackItem in the sequence, relative to the beginning of its corresponding sequence (NOT the sequence zero point). Note: This may differ from the trackItem's out point, which is relative to the source.
 
 **Type**
 
@@ -72,7 +72,7 @@ TrackItem.inPoint
 
 **Description**
 
-The in point for media, in this trackItem.
+The in point set on the source for this trackItem instance, relative to the beginning of the source.
 
 **Type**
 
@@ -152,7 +152,7 @@ TrackItem.outPoint
 
 **Description**
 
-The out point for media, in this trackItem.
+The out point set on the source for this trackItem instance, relative to the beginning of the source.
 
 **Type**
 
@@ -184,7 +184,7 @@ TrackItem.start
 
 **Description**
 
-The starting time of the trackItem. Note: This may differ, from the trackItem's in point.
+The visible start time of the trackItem in the sequence, relative to the beginning of its corresponding sequence (NOT the sequence zero point). Note: This may differ from the trackItem's in point, which is relative to the source.
 
 **Type**
 

--- a/docs/item/trackitem.rst
+++ b/docs/item/trackitem.rst
@@ -184,7 +184,7 @@ TrackItem.start
 
 **Description**
 
-The absolute start time of the trackItem, in the timeline. This does not consider the visible clip trimming (determined by ``TrackItem.inPoint`` and ``TrackItem.outPoint``). Note: This may differ, from the trackItem's in point.
+The absolute start time of the trackItem in the timeline. This does not consider the visible clip trimming (determined by ``TrackItem.inPoint`` and ``TrackItem.outPoint``). Note: This may differ, from the trackItem's in point.
 
 **Type**
 


### PR DESCRIPTION
This pull request elaborates 4 definitions to make them more helpful for developers - especially those who are new to Premiere Scripting. The following attribute definitions were updated:

* ``TrackItem.start``
* ``TrackItem.end``
* ``TrackItem.inPoint``
* ``TrackItem.outPoint``