### PR TITLE
Update repo to use common org-wide components

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
+
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
 
       - uses: actions/cache@v4
@@ -30,9 +31,8 @@ jobs:
           path: .cache
           restore-keys: |
             mkdocs-material-
-      - run: >
-          pip install
-          mkdocs-material
-          mkdocs-git-revision-date-localized-plugin
-          mkdocs-print-site-plugin
+
+      - name: Install Python dependencies
+        uses: py-actions/py-dependency-install@v4
+
       - run: mkdocs gh-deploy --force

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 *.sublime-workspace
 .DS_Store
 .vscode/
+__pycache__/
 site/
 venv/

--- a/docs/_global/.gitignore
+++ b/docs/_global/.gitignore
@@ -1,0 +1,7 @@
+*.sublime-project
+*.sublime-workspace
+.DS_Store
+.vscode/
+__pycache__/
+site/
+venv/

--- a/docs/_global/css/global-syntax-highlight.css
+++ b/docs/_global/css/global-syntax-highlight.css
@@ -1,0 +1,43 @@
+/* Set light & dark mode syntax highlight */
+
+@media screen {
+	/* Light mode */
+	[data-md-color-scheme="default"] {
+		--md-code-fg-color: #36464e;
+		--md-code-bg-color: #f5f5f5;
+		--md-code-hl-color: #4287ff;
+
+		--md-code-hl-constant-color: #6e59d9;
+		--md-code-hl-function-color: #a846b9;
+		--md-code-hl-keyword-color: #3f6ec6;
+		--md-code-hl-number-color: #d52a2a;
+		--md-code-hl-special-color: #db1457;
+		--md-code-hl-string-color: #1c7d4d;
+		--md-code-hl-comment-color: var(--md-default-fg-color--light);
+		--md-code-hl-generic-color: var(--md-default-fg-color--light);
+		--md-code-hl-name-color: var(--md-code-fg-color);
+		--md-code-hl-operator-color: var(--md-default-fg-color--light);
+		--md-code-hl-punctuation-color: var(--md-default-fg-color--light);
+		--md-code-hl-variable-color: var(--md-default-fg-color--light);
+	}
+
+	/* Dark mode */
+	[data-md-color-scheme="slate"] {
+		--md-code-bg-color: #272a35;
+		--md-code-fg-color: #d5d8e2d1;
+		--md-code-hl-color: #2977ff;
+
+		--md-code-hl-constant-color: #9383e2;
+		--md-code-hl-function-color: #c973d9;
+		--md-code-hl-keyword-color: #6791e0;
+		--md-code-hl-number-color: #e6695b;
+		--md-code-hl-special-color: #f06090;
+		--md-code-hl-string-color: #2fb170;
+		--md-code-hl-comment-color: var(--md-default-fg-color--light);
+		--md-code-hl-generic-color: var(--md-default-fg-color--light);
+		--md-code-hl-name-color: var(--md-code-fg-color);
+		--md-code-hl-operator-color: var(--md-default-fg-color--light);
+		--md-code-hl-punctuation-color: var(--md-default-fg-color--light);
+		--md-code-hl-variable-color: var(--md-default-fg-color--light);
+	}
+}

--- a/docs/_global/css/global.css
+++ b/docs/_global/css/global.css
@@ -1,0 +1,4 @@
+/* Fix issue with 'code' text in tables wrapping to multiple lines */
+td code {
+    white-space: nowrap;
+}

--- a/docs/_global/hooks/merge_inherited_config.py
+++ b/docs/_global/hooks/merge_inherited_config.py
@@ -1,0 +1,119 @@
+# Handles merging mkdocs config in a way the native inheritance feature doesn't quite cover
+#
+# This relies on a key in "extra.overrides"
+# Valid keys are `custom_dir: str` and `hooks: [-path/to.py, -path/to.py]`, e.g.
+#
+# ```yml
+# extra:
+#     overrides:
+#         custom_dir: overrides
+#         extra_css:
+#             - docs/_global/css/global.css
+#             - docs/_global/css/global-syntax-highlight.css
+#         extra_javascript:
+#             - docs/_global/js/global.js
+#         hooks:
+#             - hooks/local_override.py
+#             - hooks/local_override2.py
+#         not_in_nav:
+#             - gitignore_style/path/to/exclude
+#         theme_features:
+#             - theme.feature1
+#             - theme.feature2
+# ```
+
+import os
+
+from pathspec.gitignore import GitIgnoreSpec
+
+import mkdocs
+from mkdocs.config.defaults import MkDocsConfig
+from mkdocs.config.config_options import (File, FilesystemObject, Hooks, ListOfItems, PathSpec)
+from mkdocs.structure.files import (File as FileStructure, Files)
+
+# Load any local files into mkdocs
+def append_local_files(files: Files, config: MkDocsConfig, local_files: list[str]):
+    for local_file_path in local_files:
+        local_file = FileStructure(
+            path= local_file_path,
+            src_dir=config["docs_dir"] + "/../",
+            dest_dir=config["site_dir"],
+            use_directory_urls=False,
+        )
+
+        files.append(local_file)
+
+# Load any override hooks
+def merge_local_hooks(config: MkDocsConfig, hooks: list[str]):
+    try:
+        paths = ListOfItems(File(exists=True)).validate(hooks)
+    except Exception as e:
+        raise e
+
+    for name, path in zip(hooks, paths):
+        config.plugins[name] = Hooks._load_hook(mkdocs, name, path)
+
+# Handle multiple "not in nav" entries
+# These are of a pathspec.gitignore.GitIgnoreSpec format and need to be converted to a multiline string
+def merge_local_not_in_nav(config: MkDocsConfig, not_in_nav: list[GitIgnoreSpec]):
+    nav_str = "\n".join(not_in_nav)
+    config["not_in_nav"] += PathSpec().run_validation(nav_str)
+
+# Add additional theme_override folder
+def merge_local_theme_override(config: MkDocsConfig, custom_dir: str):
+    try:
+        local_override_path = FilesystemObject(exists=True).validate(custom_dir)
+    except Exception as e:
+        raise e
+
+    config.theme.dirs.insert(1, local_override_path)
+
+# Load any override theme features
+def merge_local_theme_features(config: MkDocsConfig, theme_features: list[str]):
+    for local_feature in theme_features:
+        config.theme["features"].append(local_feature)
+
+
+
+##### MkDocs Event Hooks
+
+def on_files(files: Files, config: MkDocsConfig):
+    if "overrides" in config.extra:
+        extra_overrides = config.extra["overrides"]
+
+        if "extra_css" in extra_overrides:
+            extra_css = extra_overrides["extra_css"]
+            append_local_files(files, config, extra_css)
+
+        if "extra_javascript" in extra_overrides:
+            extra_javascript = extra_overrides["extra_javascript"]
+            append_local_files(files, config, extra_javascript)
+
+def on_config(config: MkDocsConfig):
+    if "overrides" in config.extra:
+        extra_overrides = config.extra["overrides"]
+
+        # Keep Hooks first
+        if "hooks" in extra_overrides:
+            hooks = extra_overrides["hooks"]
+            merge_local_hooks(config, hooks)
+
+        if "custom_dir" in extra_overrides:
+            custom_dir = extra_overrides["custom_dir"]
+            merge_local_theme_override(config, custom_dir)
+
+        if "extra_css" in extra_overrides:
+            extra_css = extra_overrides["extra_css"]
+            config.extra_css.extend(extra_css)
+
+        if "extra_javascript" in extra_overrides:
+            extra_javascript = extra_overrides["extra_javascript"]
+            config.extra_javascript.extend(extra_javascript)
+
+        if "not_in_nav" in extra_overrides:
+            not_in_nav = extra_overrides["not_in_nav"]
+            merge_local_not_in_nav(config, not_in_nav)
+
+        if "theme_features" in extra_overrides:
+            theme_features = extra_overrides["theme_features"]
+            merge_local_theme_features(config, theme_features)

--- a/docs/_global/mkdocs.yml
+++ b/docs/_global/mkdocs.yml
@@ -1,0 +1,74 @@
+# Shared config for all repos
+copyright: All content is copyright Adobe Systems Incorporated.
+
+extra:
+    homepage: https://docsforadobe.dev
+
+    # Using overrides here as we can't inherit "extra_css"
+    overrides:
+        extra_css:
+            - docs/_global/css/global.css
+            - docs/_global/css/global-syntax-highlight.css
+        extra_javascript:
+            - docs/_global/js/global.js
+
+hooks:
+    - docs/_global/hooks/merge_inherited_config.py
+
+markdown_extensions:
+    admonition: {}
+    markdown_grid_tables: {}
+    md_in_html: {}
+    pymdownx.details: {}
+    pymdownx.superfences: {}
+    pymdownx.tabbed:
+        alternate_style: true
+    pymdownx.tasklist:
+        custom_checkbox: true
+    toc:
+        title: Page Contents
+        permalink: true
+        toc_depth: 3
+
+not_in_nav: |
+  _global
+
+plugins:
+    git-revision-date-localized: {}
+    search:
+        separator: '[\s\-,\.:!=\[\]()"/]+'
+
+    # Note: print-site must be last!
+    print-site:
+        add_cover_page: true
+        add_print_site_banner: true
+        cover_page_template: "docs/_global/overrides/templates/print_site_cover_page.tpl"
+        print_page_title: "Offline Docs"
+        print_site_banner_template: "docs/_global/overrides/templates/print_site_banner.tpl"
+
+theme:
+    name: material
+    custom_dir: docs/_global/overrides
+    features:
+        - announce.dismiss
+        - content.action.edit
+        - content.action.view
+        - search.highlight
+        - search.suggest
+        - toc.follow
+    palette:
+        # Palette toggle for dark mode
+        - media: "(prefers-color-scheme: dark)"
+          primary: black
+          scheme: slate
+          toggle:
+              icon: material/brightness-4
+              name: Switch to light mode
+
+        # Palette toggle for light mode
+        - media: "(prefers-color-scheme: light)"
+          primary: white
+          scheme: default
+          toggle:
+              icon: material/brightness-7
+              name: Switch to dark mode

--- a/docs/_global/overrides/404.html
+++ b/docs/_global/overrides/404.html
@@ -1,0 +1,14 @@
+{% extends "main.html" %}
+
+<!-- Extra header script to strip .html suffix from legacy links -->
+{% block extrahead %}
+<script>
+    if (window.location.href.endsWith(".html")) {
+      window.location.href = window.location.href.replace(".html", "");
+    }
+</script>
+{% endblock %}
+
+{% block content %}
+  <h1>404 - Not found</h1>
+{% endblock %}

--- a/docs/_global/overrides/main.html
+++ b/docs/_global/overrides/main.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% block announce %}
+  Welcome to the new docsforadobe guide!
+
+  This is a work in progress.
+
+  Please provide all feedback via
+  <a ref="me" href="https://github.com/orgs/docsforadobe/discussions">
+    <span class="twemoji">
+      {% include ".icons/octicons/comment-discussion-16.svg" %}
+    </span>
+    <strong>the org's discussion forum</strong>
+  </a>.
+{% endblock %}

--- a/docs/_global/overrides/partials/copyright.html
+++ b/docs/_global/overrides/partials/copyright.html
@@ -1,0 +1,25 @@
+<div class="md-copyright">
+  {% if config.copyright %}
+    <div class="md-copyright__highlight">
+      {{ config.copyright }}
+    </div>
+  {% endif %}
+  {% if not config.extra.generator == false %}
+    Made with
+    <a
+      href="https://squidfunk.github.io/mkdocs-material/"
+      target="_blank" rel="noopener"
+    >
+      Material for MkDocs
+    </a>
+  {% endif %}
+</div>
+
+<!-- Print button -->
+<div class="md-copyright">
+  {% if page.url_to_print_page %}
+  <a href="{{ page.url_to_print_page }}" title="Print Site" class="md-content__button md-icon">
+      {% include ".icons/material/printer.svg" %}
+  </a>
+  {% endif %}
+</div>

--- a/docs/_global/overrides/partials/toc-item.html
+++ b/docs/_global/overrides/partials/toc-item.html
@@ -1,0 +1,20 @@
+<li class="md-nav__item">
+	<a href="{{ toc_item.url }}" class="md-nav__link">
+		<span class="md-ellipsis">
+			{{ toc_item.title }}
+		</span>
+	</a>
+
+	<!-- Table of contents list -->
+	{% if toc_item.children %}
+		<nav class="md-nav" aria-label="{{ toc_item.title | striptags }}">
+			<ul class="md-nav__list">
+				{% for toc_item in toc_item.children %}
+				{% if not page.meta.toc_depth or toc_item.level <= page.meta.toc_depth %}
+					{% include "partials/toc-item.html" %}
+				{% endif %}
+				{% endfor %}
+			</ul>
+		</nav>
+	{% endif %}
+</li>

--- a/docs/_global/overrides/templates/print_site_banner.tpl
+++ b/docs/_global/overrides/templates/print_site_banner.tpl
@@ -1,0 +1,21 @@
+<style>
+    #print-site-banner {
+        border: 0px;
+    }
+</style>
+
+<div class="admonition info">
+
+    <p class="admonition-title">Note – This box will disappear during export!</p>
+
+    <p>This page has combined all site pages into one, and can be exported using native browser features.</p>
+
+    <p>You can export to PDF using <b>File > Print > Save as PDF</b>, or save as a single-page HTML file via <b>File > Save As</b>.</p>
+
+    <div class="admonition warning">
+        <p class="admonition-title">Warning</p>
+
+        <p>Note that users may have issues <a href="https://github.com/timvink/mkdocs-print-site-plugin/issues/56">printing to PDF on Firefox</a>.</p>
+    </div>
+
+</div>

--- a/docs/_global/overrides/templates/print_site_cover_page.tpl
+++ b/docs/_global/overrides/templates/print_site_cover_page.tpl
@@ -1,0 +1,44 @@
+<div>
+
+    {% if config.site_name %}
+        <h1>{{ config.site_name }}</h1>
+    {% endif %}
+
+    {% if config.extra.homepage %}
+        by <h3><a href="{{ config.extra.homepage }}">{{ config.extra.homepage }}</a></h3>
+    {% endif %}
+
+</div>
+
+
+<table>
+
+    {% if config.site_description %}
+    <tr>
+        <td>Description</td>
+        <td>{{ config.site_description }}</td>
+    </tr>
+    {% endif %}
+
+    {% if config.site_url %}
+    <tr>
+        <td>Hosted at</td>
+        <td>{{ config.site_url }}</td>
+    </tr>
+    {% endif %}
+
+    {% if config.repo_url %}
+    <tr>
+        <td>Repository</td>
+        <td><a href="{{ config.repo_url }}">{{ config.repo_url }}</a></td>
+    </tr>
+    {% endif %}
+
+    {% if config.copyright %}
+    <tr>
+        <td>Copyright</td>
+        <td>{{ config.copyright }}</td>
+    </tr>
+    {% endif %}
+
+</table>

--- a/docs/_global/readme.md
+++ b/docs/_global/readme.md
@@ -1,0 +1,11 @@
+# docsforadobe.dev MkDocs Config
+
+This repo holds the common components shared between this org's hosted MkDocs documentation projects.
+
+The idea is that this repo will be kept up-to-date with global config, and each child repo will use the provided script to download the latest commit from this repo, and have its "local" MkDocs config point to the downloaded files from this repo.
+
+In all cases, each child repo will be able to *override* config items here as needed.
+
+## Updating This Repo
+
+See [Modifying Common Components](https://docsforadobe.dev/contributing/common-components/modifying-common-components/) in the org contribution guide for info on how this repo works, and best practices for modifying it.

--- a/docs/_global/requirements.txt
+++ b/docs/_global/requirements.txt
@@ -1,0 +1,5 @@
+markdown_grid_tables
+mkdocs
+mkdocs-git-revision-date-localized-plugin
+mkdocs-material
+mkdocs-print-site-plugin

--- a/docs/_global/scripts/update-common-components.py
+++ b/docs/_global/scripts/update-common-components.py
@@ -1,0 +1,30 @@
+import os
+import shutil
+import tarfile
+import tempfile
+import urllib.request
+
+org_name = "docsforadobe"
+repo_name = "docsforadobe-mkdocs-config"
+destination_dir = "./docs/_global"
+
+def download_github_repo(org_name, repo_name, destination_dir):
+    tar_url = f"https://api.github.com/repos/{org_name}/{repo_name}/tarball/main"
+
+    response = urllib.request.urlopen(tar_url)
+
+    if (response):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            tar = tarfile.open(fileobj=response, mode="r|gz")
+            tar_extraction_path = os.path.join(temp_dir, tar.firstmember.name)
+
+            tar.extractall(path=temp_dir)
+
+            # If already exist, remove first
+            if (os.path.isdir(destination_dir)):
+                shutil.rmtree(destination_dir)
+
+            # Move from temp folder to destination folder
+            shutil.move(tar_extraction_path, destination_dir)
+
+download_github_repo(org_name, repo_name, destination_dir)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,10 +1,13 @@
-# Site metadata
+# Do not modify below line! Inherits common components.
+INHERIT: ./docs/_global/mkdocs.yml
+
+#### Site metadata & nav - update these!
+
 site_name: Premiere Pro Scripting Guide
 site_url: https://ppro-scripting.docsforadobe.dev/
 repo_url: https://github.com/docsforadobe/premiere-scripting-guide/
 repo_name: "premiere-scripting-guide"
 
-# Customize navigation
 nav:
     - Home: index.md
     - Introduction:
@@ -44,66 +47,29 @@ nav:
         - TrackCollection object: collection/trackcollection.md
         - TrackItemCollection object: collection/trackitemcollection.md
 
-
-# Do not touch below-- shared for all docs
-
-copyright: All content is copyright Adobe Systems Incorporated.
+#### Additional config below - modify sparingly!
 
 extra:
-    homepage: https://docsforadobe.dev
+    # Custom guide-specific overrides
+    #
+    # Valid keys are:
+    #     custom_dir: str
+    #     hooks:
+    #         - path/to/hook.py
+    #     not_in_nav:
+    #         - gitignore_style/path/to/exclude
+    #     theme_features:
+    #         - theme.feature
+    overrides: {}
 
-theme:
-    name: material
-    custom_dir: overrides
-    features:
-        - announce.dismiss
-        - content.action.edit
-        - content.action.view
-        - search.highlight
-        - search.suggest
-        - toc.follow
-    palette:
-        # Palette toggle for dark mode
-        - media: "(prefers-color-scheme: dark)"
-          primary: black
-          scheme: slate
-          toggle:
-              icon: material/brightness-4
-              name: Switch to light mode
-
-        # Palette toggle for light mode
-        - media: "(prefers-color-scheme: light)"
-          primary: white
-          scheme: default
-          toggle:
-              icon: material/brightness-7
-              name: Switch to dark mode
-
+# CSS for this guide
 extra_css:
-    # CSS shared between the whole org
-    - https://docsforadobe.dev/_global/global.css
-    - https://docsforadobe.dev/_global/global-syntax-highlight.css
-
-    # CSS specific to this file
     - _static/extra.css
 
-markdown_extensions:
-    - admonition
-    - pymdownx.superfences
-    - toc:
-        title: Page Contents
-        permalink: true
-        toc_depth: 3
+# JS for this guide
+extra_javascript:
+    - _static/extra.js
 
-plugins:
-    - git-revision-date-localized
-    - search:
-        separator: '[\s\-,\.:!=\[\]()"/]+'
+markdown_extensions: {}
 
-    # Note: print-site must be last!
-    - print-site:
-        add_cover_page: true
-        add_print_site_banner: true
-        cover_page_template: "overrides/templates/print_site_cover_page.tpl"
-        print_page_title: "Offline Docs"
-        print_site_banner_template: "overrides/templates/print_site_banner.tpl"
+plugins: {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,1 @@
-mkdocs
-mkdocs-material
-mkdocs-git-revision-date-localized-plugin
-mkdocs-print-site-plugin
+-r docs/_global/requirements.txt


### PR DESCRIPTION
- Add a script that will fetch current status of [docsforadobe-mkdocs-config](https://github.com/docsforadobe/docsforadobe-mkdocs-config) repo and download to `/docs/_global`
- Update `./mkdocs.yml` and `./requirements.txt` to reference this folder
- Update `ci.yml` to use `./requirements.txt`